### PR TITLE
Fix/14 user.favorite field wrong type

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
   },
   "ignorePatterns": ["src/generated", "dist"],
   "rules": {
+    "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-unused-vars": "error",
     "no-console": "warn"

--- a/src/graphql/group/__test__/resolver.test.ts
+++ b/src/graphql/group/__test__/resolver.test.ts
@@ -9,16 +9,16 @@ import {
 } from "../../../generated/types";
 import { testUtils } from "../../../test/jest.setup";
 
-const mockUser: UserDbObject = {
-  _id: new ObjectId(),
-  name: "mock-user",
-  favorite: ["restaurant-1", "restaurant-2"]
-};
-
 const mockRestaurant: RestaurantDbObject = {
   _id: new ObjectId(),
   name: "mock-restaurant",
   address: "mock-address"
+};
+
+const mockUser: UserDbObject = {
+  _id: new ObjectId(),
+  name: "mock-user",
+  favorite: [mockRestaurant._id]
 };
 
 const mockGroupId = new ObjectId();

--- a/src/graphql/poll/__test__/resolver.test.ts
+++ b/src/graphql/poll/__test__/resolver.test.ts
@@ -12,12 +12,6 @@ import {
 } from "../../../generated/types";
 import { testUtils } from "../../../test/jest.setup";
 
-const mockUser: UserDbObject = {
-  _id: new ObjectId(),
-  name: "mock-user",
-  favorite: ["restaurant-1", "restaurant-2"]
-};
-
 const mockRestaurants: RestaurantDbObject[] = [
   {
     _id: new ObjectId(),
@@ -30,6 +24,12 @@ const mockRestaurants: RestaurantDbObject[] = [
     address: "mock-address"
   }
 ];
+
+const mockUser: UserDbObject = {
+  _id: new ObjectId(),
+  name: "mock-user",
+  favorite: [mockRestaurants[0]._id, mockRestaurants[1]._id]
+};
 
 const mockPollId = new ObjectId();
 const mockPoll: CreatePollInput & { _id: ObjectId } = {

--- a/src/graphql/user/schema.graphql
+++ b/src/graphql/user/schema.graphql
@@ -2,7 +2,7 @@
 type User @entity {
   id: ID! @id
   name: String! @column
-  favorite: [String!] @column
+  favorite: [Restaurant!] @link
 }
 
 type PagedUser {
@@ -15,17 +15,17 @@ type PagedUser {
 # ----- input types -----
 input UsersQuery {
   name: String
-  favorite: [String!]
+  favorite: [ID!]
 }
 
 input CreateUserInput {
   name: String!
-  favorite: [String!]!
+  favorite: [ID!]!
 }
 
 input UpdateUserInput {
   name: String
-  favorite: [String!]
+  favorite: [ID!]
 }
 
 # ----- query and muate -----


### PR DESCRIPTION
### Related Issues
- closed #14 

# Description
- 修正 User.favorite 欄位 type
- 修正相關測試
- eslintrc 關閉 `ban-ts-ignore` rule

# Note
- `favorite` subResolver 無法取得正確 user parent type，因為有 UserMapperType 覆寫原本的 parent type
  目前還沒找到「本身 resolver」、「link entity」都能 map 到正確 parent type 的標法

